### PR TITLE
feat: Enable adding attendees to calendar events

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,9 @@ import {
   ListEmailsQuerySchema,
   SearchPeopleQuerySchema,
   GetScheduleQuerySchema,
-  FindMeetingTimesQuerySchema
+  FindMeetingTimesQuerySchema,
+  AddAttendeesToEventSchema,
+  AddAttendeesToEventParams
 } from "./types.js";
 import { graphClient } from "./graphClient.js";
 
@@ -722,6 +724,35 @@ server.prompt(
   }
 );
 
+// New tool to add attendees to a calendar event
+server.tool(
+  "addAttendeesToCalendarEvent",
+  "Adds one or more attendees to an existing calendar event. Fetches the event, merges new attendees with existing ones (avoiding duplicates), and updates the event.",
+  AddAttendeesToEventSchema.shape,
+  async (params: AddAttendeesToEventParams) => {
+    try {
+      const updatedEvent = await graphClient.addAttendeesToEvent(params.eventId, params.attendees);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(updatedEvent, null, 2)
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error adding attendees to calendar event: ${error instanceof Error ? error.message : String(error)}`
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
 
 // Connect the server to stdio transport
 server.connect(new StdioServerTransport());

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,28 @@ export const CreateEventSchema = z.object({
 
 export type CreateEventParams = z.infer<typeof CreateEventSchema>;
 
+// Schema for Attendee Type )
+export const AttendeeTypeSchema = z.enum(["required", "optional", "resource"]);
+
+// Schema for a single Attendee 
+export const AttendeeSchema = z.object({
+  emailAddress: z.object({
+    address: z.string().describe("The email address of the attendee."),
+    name: z.string().optional().describe("The display name of the attendee.")
+  }),
+  type: AttendeeTypeSchema.optional().describe("The type of attendee. Default is 'required'.")
+});
+
+export type Attendee = z.infer<typeof AttendeeSchema>;
+
+// Schema for adding attendees to an event
+export const AddAttendeesToEventSchema = z.object({
+  eventId: z.string().describe("ID of the calendar event to add attendees to."),
+  attendees: z.array(AttendeeSchema).min(1).describe("List of attendees to add to the event.")
+});
+
+export type AddAttendeesToEventParams = z.infer<typeof AddAttendeesToEventSchema>;
+
 // Schema for listing events query parameters
 export const ListEventsQuerySchema = z.object({
   startDateTime: z.string().optional(),


### PR DESCRIPTION
This commit introduces the capability to add new attendees, or remove existing ones from an existing calendar event.

Key enhancements include:
- Definition of new data structures '("AttendeeSchema", "AddAttendeesToEventSchema") in "src/types.ts" to model attendees and the parameters for the add operation.
- Extension of "CalendarEventSchema" and "CreateEventSchema" in "src/types.ts" to optionally include attendees.
- Implementation of an "addAttendeesToEvent" method in "src/graphClient.ts". This method intelligently merges new attendees with existing ones, to safe guard against creating duplicates, and updates the event. It utilises a PATCH request that preserves existing attendees by fetching the current event, combining its attendees with the new one (or without the removed ones), and submitting the complete attendee list in a single update. (See https://learn.microsoft.com/en-us/graph/api/event-update?view=graph-rest-1.0&tabs=javascript documentation)
- Introduction of a new MCP tool, "addAttendeesToCalendarEvent", in "src/index.ts", which exposes this functionality. On branch main Your branch is up to date with 'origin/main'.

 Changes to be committed:
	modified:   src/graphClient.ts
	modified:   src/index.ts
	modified:   src/types.ts